### PR TITLE
Update links to Strapi documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Customizing modules will differ slightly for each plugin. The `strapi-plugin-doc
 ## References
 
 * [Strapi.io](https://strapi.io/)
-* [Strapi Documentation](https://strapi.io/documentation/v3.x)
-* [Strapi Quick Start Guide](https://strapi.io/documentation/v3.x/getting-started/introduction.html)
+* [Strapi Documentation](https://strapi.io/documentation/developer-docs/latest/getting-started/introduction.html)
+* [Strapi Quick Start Guide](https://strapi.io/documentation/developer-docs/latest/getting-started/quick-start.html)
 * [Node.js on Platform.sh](https://docs.platform.sh/languages/nodejs.html)
 * [Multi-app on Platform.sh](https://docs.platform.sh/configuration/app/multi-app.html#multiple-applications)


### PR DESCRIPTION
Hello! I'm a technical writer at Strapi, maintaining our documentation.
I noticed that the two links to our documentation inside your README are outdated.
So here's a little PR to fix it 🙂 
